### PR TITLE
Enforce hardware-specific drives.g file

### DIFF
--- a/milo/common/drives.g
+++ b/milo/common/drives.g
@@ -1,0 +1,1 @@
+abort { "Machine-specific configuration does not contain a drives.g file!" }


### PR DESCRIPTION
Previously, the common `drives.g` file would not trigger an error if it were not overridden by a hardware-specific `drives.g` file. Since drives are fundamentally hardware-specific, we should enforce this by aborting if a `drives.g` file is not generated.