### PR TITLE
Update LDO kit toolsetter pin

### DIFF
--- a/milo/ldo-kit-fly-cdyv3/toolsetter.g
+++ b/milo/ldo-kit-fly-cdyv3/toolsetter.g
@@ -8,4 +8,4 @@
 ; T1200    - Travel speed, mm/min
 ; F600:300 - Probe Speed rough / fine, mm/min
 
-M558 K1 P8 C"!PA9" H5 A5 S0.01 T1200 F600:300
+M558 K1 P8 C"!zmax" H5 A5 S0.01 T1200 F600:300


### PR DESCRIPTION
Our initial configuration during Dave's testing used the `PA9` pin for the toolsetter due to it not working with the `zmax` port unless the correct jumper is in place to set all the endstops to 5v.

Adding the jumper for 5v is in the LDO kit instructions so we should use the intended pin for our config.