### PR TITLE
Switch to using Pin IDs instead of aliases

### DIFF
--- a/milo-v1.5/common/M552.1.g
+++ b/milo-v1.5/common/M552.1.g
@@ -8,6 +8,15 @@
 ; If using this macro to switch between client and AP mode, you
 ; must switch to idle mode first (S0).
 
+; WARNING: Do not call this directly from config.g or a macro run
+; from config.g, as it will cause a boot loop - config.g sets up
+; asynchronously, and the WiFi adapter comes up after the
+; configuration process is complete. This macro is intended to be
+; used during complex network configuration setups, such as when we
+; need to update the WiFi module and need to know the module is in
+; a particular state before we can proceed.
+
+
 ; List of expected modes when passed an S-number.
 ; First one corresponds to S=-1, second to S=0, etc.
 

--- a/milo-v1.5/ldo-kit-fly-cdyv3/fans.g
+++ b/milo-v1.5/ldo-kit-fly-cdyv3/fans.g
@@ -3,8 +3,8 @@
 ; TODO: Is Q500 appropriate?
 
 ; Configure fan port 0 and 1 and enable at startup
-M950 F0 C"fan0" Q500
+M950 F0 C"PA_0" Q500
 M106 P0 S1 H-1
 
-M950 F1 C"fan1" Q500
+M950 F1 C"PA_1" Q500
 M106 P1 S1 H-1

--- a/milo-v1.5/ldo-kit-fly-cdyv3/limits.g
+++ b/milo-v1.5/ldo-kit-fly-cdyv3/limits.g
@@ -16,10 +16,10 @@ M208 X335 Y208 Z0 S0
 ; Z homes upwards to zero.
 
 ; Endstop X=0: NC
-M574 X1 S1 P"xmin"
+M574 X1 S1 P"PC_7"
 
 ; Endstop Y=MAX: NC
-M574 Y2 S1 P"ymin"
+M574 Y2 S1 P"PD_11"
 
 ; Endstop Z=MAX: NC
-M574 Z2 S1 P"zmin"
+M574 Z2 S1 P"PB_10"

--- a/milo-v1.5/ldo-kit-fly-cdyv3/spindle.g
+++ b/milo-v1.5/ldo-kit-fly-cdyv3/spindle.g
@@ -4,4 +4,4 @@
 ; Minimum is achieved at 0% pulse width, Maximum is at 100% pulse width.
 
 ; TODO: We need to work out a good value for Q.
-M950 R0 C"PE6+!Laser" L24000 Q100
+M950 R0 C"PE_6+!PB_9" L24000 Q100

--- a/milo-v1.5/ldo-kit-fly-cdyv3/toolsetter.g
+++ b/milo-v1.5/ldo-kit-fly-cdyv3/toolsetter.g
@@ -8,4 +8,4 @@
 ; T1200    - Travel speed, mm/min
 ; F600:300 - Probe Speed rough / fine, mm/min
 
-M558 K1 P8 C"!zmax" H5 A5 S0.01 T1200 F600:300
+M558 K1 P8 C"!PB_11" H5 A5 S0.01 T1200 F600:300


### PR DESCRIPTION
There was a mismatch between the teamgloomy documentation and firmware pin aliases, and some confusion about how the spindle RPM line should be connected with the LDO kit.

The upshot of it is this - the "Neopixel" port (`PD_15`) that the LDO wiring guide connects the spindle RPM to is problematic in 2 ways:

- The Neopixel port is directly linked to the onboard status LED, and requires `led.diagnostic=NoPin` added to `board.txt` to stop RRF from changing the output of the port in response to status changes on the board. This also means that the onboard status LED would stop working.
- The Neopixel port is pulled high in hardware, so in the (_very_) unlikely event of a partial hardware failure, that might mean the spindle RPM being set to maximum. From a safety perspective this is not good, as it could mean the spindle can start unexpectedly.

I propose this PR - we don't update the Spindle RPM pin from `PE_6`, which _should_ correctly support spindle RPM and is pulled low in hardware so not susceptible to the failure mode of the Neopixel port above.

And additionally, we should have LDO update their wiring documentation to account for this.