### PR TITLE
Fix M552 S-param validation

### DIFF
--- a/milo-v1.5/common/M552.1.g
+++ b/milo-v1.5/common/M552.1.g
@@ -40,13 +40,13 @@ var isWifi = { network.interfaces[var.iface].type == "wifi" }
 
 var ifaceType = { var.isWifi ? "WiFi" : "LAN" }
 
-; Target state index
-var stateID = { var.isWifi ? param.S+1 : param.S }
-
 ; Validate S parameter based on interface type.
 ; NOTE: S=-1 and S=2 are not valid for Ethernet interfaces.
 if { !exists(param.S) || var.stateID < 0 || (var.isWifi && var.stateID >= #var.wStates) || (!var.isWifi && var.stateID >= #var.eStates) }
     abort {"Must provide valid target mode number with S parameter!"}
+
+; Target state index
+var stateID = { var.isWifi ? param.S+1 : param.S }
 
 ; Get expected state based on interface type.
 ; Ethernet does not have a -1 state so we don't


### PR DESCRIPTION
The S parameter was not validated before it was used due to an ordering issue. 

Reorder the validation so this no longer triggers an RRF error.