### PR TITLE
Load MillenniumOS if installed

### DIFF
--- a/milo-v1.5/common/config.g
+++ b/milo-v1.5/common/config.g
@@ -26,3 +26,7 @@ if { fileexists("toolsetter.g") }
     M98 P"toolsetter.g"
 if { fileexists("touchprobe.g") }
     M98 P"touchprobe.g"
+
+; Load MillenniumOS if it has been installed.
+if { fileexists("mos.g") }
+    M98 P"mos.g"


### PR DESCRIPTION
This is a nice-to-have but also fixes an issue with upgrades, in that we were asking the user to edit `config.g` to install MillenniumOS. We now just check if `mos.g` exists and load it if so, which allows the operator to not have to edit the `config.g` file and will always load MillenniumOS, even after an upgrade.