### PR TITLE
Increase X and Y current to 1.8A on LDO kit config

### DIFF
--- a/milo-v1.5/ldo-kit-fly-cdyv3/drives.g
+++ b/milo-v1.5/ldo-kit-fly-cdyv3/drives.g
@@ -25,7 +25,7 @@ M350 X32 Y32 Z32
 M92 X800 Y800 Z1600
 
 ; Set motor currents (mA)
-M906 X1200 Y1200 Z1200
+M906 X1800 Y1800 Z1200
 
 ; Set standstill current reduction to 10%
 M917 X10 Y10 Z10


### PR DESCRIPTION
The X and Y currents were set very conservatively on the LDO kit, so these have now been increased to 1.8A peak. We leave Z at the previous value as this is the driver most likely to overheat during standstill, and the axis least affected by machining torque.