### PR TITLE
Make release notes more obvious

### DIFF
--- a/dist/functions.sh
+++ b/dist/functions.sh
@@ -120,9 +120,11 @@ function build_release() {
 	[[ ! -z "${ENABLE_RNOTES}" ]] && {
 		cat <<-EOF >>"${RNOTES_PATH}"
 		### ${MACHINE_ID^^}
-		* **RepRapFirmware / DuetWifiServer**: ${RRF_FIRMWARE_SRC_NAME} - ${RRF_FIRMWARE_URL}
-		* **DuetWebControl**: ${DWC_SRC_NAME} - ${DWC_URL}
-		* **Optionally, MillenniumOS**: ${MOS_SRC_NAME} - ${MOS_URL}
+
+		* **RepRapFirmware / DuetWifiServer**: \`${RRF_FIRMWARE_SRC_NAME}\` - ${TG_RELEASE}
+		* **DuetWebControl**: \`${DWC_SRC_NAME}\` - ${DUET_RELEASE}
+		* **Configuration**: \`${COMMON_DIR}\` and \`${MACHINE_DIR}\` - ${COMMIT_ID}
+		* **Optionally, MillenniumOS**: \`${MOS_SRC_NAME}\` - ${MOS_RELEASE}
 
 		---
 

--- a/dist/release-all.sh
+++ b/dist/release-all.sh
@@ -21,6 +21,7 @@ cat <<-EOF >>"${RNOTES_PATH}"
 	# Release ${COMMIT_ID}
 
 	## Milo V1.5 - Release Contents
+
 EOF
 
 # Build the release package for this machine
@@ -32,6 +33,7 @@ build_release
 
 cat <<-EOF >>"${RNOTES_PATH}"
 	## Upgrading
+
 	* You can upload any of these release zip files from Duet Web Control (DWC), via the "Files -> System" link in the menu.
 	* **NOTE**: If you upload the file via DWC and click 'Yes' to upgrade, the WiFi module will be flashed twice. There is currently no way around this, we need to do this to support extracting the file directly to the SD card for initial installations.
 	* The first time your machine reboots after installing the new release, it will switch back into Access Point mode and will _not_ connect to your WiFi network if it was configured to do so - this is because WiFi network details might be wiped when the WiFi module is updated, and bringing the board back up in AP mode allows recovery without having to connect over USB.

--- a/dist/release-milo-v1.5.env
+++ b/dist/release-milo-v1.5.env
@@ -5,18 +5,18 @@ DUET_RELEASE="3.5.1"
 # This is annoying but GitHub creates the release tag from the version
 # tag, so the release cannot be found using the version directly.
 MOS_RELEASE_TAG="release-f5e76c62a2c7a6e9d62784b1108deef0246b0cda"
-MOS_RELEASE="v0.2.2"
+MOS_RELEASE="0.2.2"
 
 
 TG_RELEASE_URL="${TEAMGLOOMY_RELEASES}/v${TG_RELEASE}"
 DUET_RELEASE_URL="${DUET_RELEASES}/${DUET_RELEASE}"
 MOS_RELEASE_URL="${MILLENNIUMOS_RELEASES}/${MOS_RELEASE_TAG}"
 
-MOS_SRC_NAME="mos-release-${MOS_RELEASE}.zip"
+MOS_SRC_NAME="mos-release-v${MOS_RELEASE}.zip"
 DWC_SRC_NAME="DuetWebControl-SD.zip"
 
 DWC_DST_NAME="dwc-${DUET_RELEASE}.zip"
-MOS_DST_NAME="mos-${MOS_RELEASE}.zip"
+MOS_DST_NAME="mos-v${MOS_RELEASE}.zip"
 
 RRF_FIRMWARE_ZIP_NAME="STM32RepRapFirmwareWiFi.zip"
 


### PR DESCRIPTION
No more links in the release notes tricking people into downloading the files that are already included.