### PR TITLE
Check that endstops are actually triggered during homing

### DIFF
--- a/milo-v1.5/common/homeall.g
+++ b/milo-v1.5/common/homeall.g
@@ -5,10 +5,17 @@ G91
 G21
 G94
 
+; Home Z first to move spindle out of the way
 M98 P"homez.g"
 
 ; Move quickly to X and Y axis endstops and stop there (first pass)
 G53 G1 H1 X{-(move.axes[0].max - move.axes[0].min + 5) } Y{ move.axes[1].max - move.axes[1].min + 5 } F{1800}
+
+; Endstops should now be triggered, verify
+if { ! sensors.endstops[0].triggered }
+    abort {"X endstop not triggered after full axis travel. Check that your X motor is connected and the endstop is working!"}
+if { ! sensors.endstops[1].triggered }
+    abort {"Y endstop not triggered after full axis travel. Check that your Y motor is connected and the endstop is working!"}
 
 ; Move away from X and Y endstops
 G53 G1 H2 X{5} Y{-5}

--- a/milo-v1.5/common/homex.g
+++ b/milo-v1.5/common/homex.g
@@ -11,6 +11,10 @@ G53 G0 Z{move.axes[2].max}
 ; Move quickly to X axis endstop and stop there (first pass)
 G53 G1 H1 X{-(move.axes[0].max - move.axes[0].min + 5) } F{1800}
 
+; Endstop should now be triggered, verify
+if { ! sensors.endstops[0].triggered }
+    abort {"X endstop not triggered after full axis travel. Check that your X motor is connected and the endstop is working!"}
+
 ; Move away from X endstop
 G53 G1 H2 X{5}
 

--- a/milo-v1.5/common/homey.g
+++ b/milo-v1.5/common/homey.g
@@ -11,6 +11,10 @@ G53 G0 Z{move.axes[2].max}
 ; Move quickly to Y axis endstop and stop there (first pass)
 G53 G1 H1 Y{ move.axes[1].max - move.axes[1].min + 5 } F{1800}
 
+; Endstop should now be triggered, verify
+if { ! sensors.endstops[1].triggered }
+    abort {"Y endstop not triggered after full axis travel. Check that your Y motor is connected and the endstop is working!"}
+
 ; Move away from Y endstop
 G53 G1 H2 Y{-5}
 

--- a/milo-v1.5/common/homez.g
+++ b/milo-v1.5/common/homez.g
@@ -15,6 +15,10 @@ if { state.currentTool != -1 }
 ; Raise Z towards endstop at high speed
 G53 G1 H1 Z{move.axes[2].max - move.axes[2].min + 5} F{1800}
 
+; Endstop should now be triggered, verify
+if { ! sensors.endstops[2].triggered }
+    abort {"Z endstop not triggered after full axis travel. Check that your Z motor is connected and the endstop is working!"}
+
 ; Move away from Z endstop
 G53 G1 H2 Z{-5}
 

--- a/milo-v1.5/reference-skr3-ez-5160/homeall.g
+++ b/milo-v1.5/reference-skr3-ez-5160/homeall.g
@@ -11,6 +11,12 @@ M98 P"homez.g"
 ; Move quickly to X and Y axis endstops and stop there (first pass)
 G53 G1 H1 X{-(move.axes[0].max - move.axes[0].min + 5) } Y{ move.axes[1].max - move.axes[1].min + 5 } F{3600}
 
+; Endstops should now be triggered, verify
+if { ! sensors.endstops[0].triggered }
+    abort {"X endstop not triggered after full axis travel. Check that your X motor is connected and the endstop is working!"}
+if { ! sensors.endstops[1].triggered }
+    abort {"Y endstop not triggered after full axis travel. Check that your Y motor is connected and the endstop is working!"}
+
 ; Move away from X and Y endstops
 G53 G1 H2 X{5} Y{-5}
 

--- a/milo-v1.5/reference-skr3-ez-5160/homex.g
+++ b/milo-v1.5/reference-skr3-ez-5160/homex.g
@@ -11,6 +11,10 @@ G53 G0 Z{move.axes[2].max}
 ; Move quickly to X axis endstop and stop there (first pass)
 G53 G1 H1 X{-(move.axes[0].max - move.axes[0].min + 5) } F{3600}
 
+; Endstop should now be triggered, verify
+if { ! sensors.endstops[0].triggered }
+    abort {"X endstop not triggered after full axis travel. Check that your X motor is connected and the endstop is working!"}
+
 ; Move away from X endstop
 G53 G1 H2 X{5}
 

--- a/milo-v1.5/reference-skr3-ez-5160/homey.g
+++ b/milo-v1.5/reference-skr3-ez-5160/homey.g
@@ -11,6 +11,10 @@ G53 G0 Z{move.axes[2].max}
 ; Move quickly to Y axis endstop and stop there (first pass)
 G53 G1 H1 Y{ move.axes[1].max - move.axes[1].min + 5 } F{3600}
 
+; Endstop should now be triggered, verify
+if { ! sensors.endstops[1].triggered }
+    abort {"Y endstop not triggered after full axis travel. Check that your Y motor is connected and the endstop is working!"}
+
 ; Move away from Y endstop
 G53 G1 H2 Y{-5}
 

--- a/milo-v1.5/reference-skr3-ez-5160/homez.g
+++ b/milo-v1.5/reference-skr3-ez-5160/homez.g
@@ -15,6 +15,10 @@ if { state.currentTool != -1 }
 ; Raise Z towards endstop at high speed
 G53 G1 H1 Z{move.axes[2].max - move.axes[2].min + 5} F{2000}
 
+; Endstop should now be triggered, verify
+if { ! sensors.endstops[2].triggered }
+    abort {"Z endstop not triggered after full axis travel. Check that your Z motor is connected and the endstop is working!"}
+
 ; Move away from Z endstop
 G53 G1 H2 Z{-5}
 


### PR DESCRIPTION
RRF's H1 / H2 move modes won't error if endstops are not activated during moves so we should check that endstops are triggered after moving towards them.