### PR TITLE
Add missing fans.g config

### DIFF
--- a/milo-v1.5/reference-skr3-ez-5160/fans.g
+++ b/milo-v1.5/reference-skr3-ez-5160/fans.g
@@ -1,0 +1,5 @@
+; fans.g - Configures fans
+
+; Configure fan port 0 and enable at startup
+M950 F0 C"PB_7" Q500
+M106 P0 S1 H-1


### PR DESCRIPTION
Configure a single always-on fan for board cooling.