### PR TITLE
Add `user-config.g` example file and loader

### DIFF
--- a/milo-v1.5/common/config.g
+++ b/milo-v1.5/common/config.g
@@ -27,6 +27,10 @@ if { fileexists("toolsetter.g") }
 if { fileexists("touchprobe.g") }
     M98 P"touchprobe.g"
 
+; Load a user configuration file if it exists
+if { fileexists("user-config.g") }
+    M98 P"user-config.g"
+
 ; Load MillenniumOS if it has been installed.
 if { fileexists("mos.g") }
     M98 P"mos.g"

--- a/milo-v1.5/common/user-config.g.example
+++ b/milo-v1.5/common/user-config.g.example
@@ -1,0 +1,7 @@
+; user-config.g - Configure machine or user-specific overrides
+
+; Use this to set calibrated steps-per-mm
+M92 X800 Y800 Z1600
+
+; Use this to set backlash compensation
+M425 X0.00 Y0.00 Z0.00 S10


### PR DESCRIPTION
Add a file that will not be overwritten on update where the operator can put their own settings, for example calibrated steps-per-mm using `M92` or backlash compensation using `M425`.