### PR TITLE
Fix release issues

### DIFF
--- a/dist/functions.sh
+++ b/dist/functions.sh
@@ -93,15 +93,17 @@ function build_release() {
 	# RRF STM32 is now released as a single Zip file
 	# Copy firmware files to correct location
 	[[ ! -f "${CACHE_DIR}/${RRF_FIRMWARE_ZIP_NAME}" ]] && {
-		wget -O "${CACHE_DIR}/${RRF_FIRMWARE_ZIP_NAME}" "${RRF_FIRMWARE_URL}"
+		wget -O "${CACHE_DIR}/${RRF_FIRMWARE_ZIP_NAME}" "${RRF_FIRMWARE_URL}" || { echo "Failed to download ${RRF_FIRMWARE_URL}"; exit 1; }
 	}
 
 	[[ ! -f "${CACHE_DIR}/${DWC_DST_NAME}" ]] && {
-		wget -O "${CACHE_DIR}/${DWC_DST_NAME}" "${DWC_URL}"
+		wget -O "${CACHE_DIR}/${DWC_DST_NAME}" "${DWC_URL}" || { echo "Failed to download ${DWC_URL}"; exit 1; }
+
 	}
 
 	[[ ! -f "${CACHE_DIR}/${MOS_DST_NAME}" ]] && {
-		wget -O "${CACHE_DIR}/${MOS_DST_NAME}" "${MOS_URL}"
+		wget -O "${CACHE_DIR}/${MOS_DST_NAME}" "${MOS_URL}" || { echo "Failed to download ${MOS_URL}"; exit 1; }
+
 	}
 
 	# Unzip RRF firmware to cache dir

--- a/dist/release-all.sh
+++ b/dist/release-all.sh
@@ -17,7 +17,7 @@ ENABLE_RNOTES="aww yiss"
 
 # Add release notes header
 rm -f "${RNOTES_PATH}"
-cat <<-EOF >>"${RNOTES_PATH}"
+cat <<-"EOF" >>"${RNOTES_PATH}"
 	# Release ${COMMIT_ID}
 
 	## Upgrading

--- a/dist/release-milo-v1.5.env
+++ b/dist/release-milo-v1.5.env
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-TG_RELEASE="3.5.2-rc1"
-DUET_RELEASE="3.5.2-rc1"
+TG_RELEASE="3.5.2-rc.1"
+DUET_RELEASE="3.5.2-rc.1"
 
 # This is annoying but GitHub creates the release tag from the version
 # tag, so the release cannot be found using the version directly.


### PR DESCRIPTION
Make sure a release is aborted if any files cannot be downloaded.

Make sure backticks in release notes are not evaluated by shell.

Fix version string for RRF RC release.