### PR TITLE
Remove MOS_RELEASE_TAG

### DIFF
--- a/dist/release-milo-v1.5.env
+++ b/dist/release-milo-v1.5.env
@@ -1,16 +1,11 @@
 #!/usr/bin/env bash
 TG_RELEASE="3.5.3"
 DUET_RELEASE="3.5.3"
-
-# This is annoying but GitHub creates the release tag from the version
-# tag, so the release cannot be found using the version directly.
-MOS_RELEASE_TAG="release-5dbd95efd2a9bb0ca6994fa8fe6ca7b124e83c23"
 MOS_RELEASE="0.4.0"
-
 
 TG_RELEASE_URL="${TEAMGLOOMY_RELEASES}/v${TG_RELEASE}"
 DUET_RELEASE_URL="${DUET_RELEASES}/${DUET_RELEASE}"
-MOS_RELEASE_URL="${MILLENNIUMOS_RELEASES}/${MOS_RELEASE_TAG}"
+MOS_RELEASE_URL="${MILLENNIUMOS_RELEASES}/v${MOS_RELEASE}"
 
 MOS_SRC_NAME="mos-release-v${MOS_RELEASE}.zip"
 DWC_SRC_NAME="DuetWebControl-SD.zip"


### PR DESCRIPTION
Requires https://github.com/MillenniumMachines/MillenniumOS/pull/165 to be merged first