### PR TITLE
Add Safety Net

### DIFF
--- a/milo-v1.5/common/toolsetter.g.example
+++ b/milo-v1.5/common/toolsetter.g.example
@@ -9,7 +9,7 @@
 
 ; P8       - Unfiltered switch
 ; C"<pin>" - Input pin
-; H5       - Dive height (height for repeated probes)
+; H8       - Dive height (height for repeated probes)
 ; A5       - Max number of probes
 ; S0.01    - Required tolerance
 ; T1200    - Travel speed, mm/min
@@ -17,4 +17,4 @@
 
 ; Configure toolsetter. You must set the C"..." parameter to
 ; the pin identifier where your toolsetter input is connected.
-M558 K1 P8 C"<pin>" H5 A5 S0.01 T1200 F600:300
+M558 K1 P8 C"<pin>" H8 A5 S0.01 T1200 F600:300

--- a/milo-v1.5/ldo-kit-fly-cdyv3/toolsetter.g
+++ b/milo-v1.5/ldo-kit-fly-cdyv3/toolsetter.g
@@ -8,4 +8,4 @@
 ; T1200    - Travel speed, mm/min
 ; F600:300 - Probe Speed rough / fine, mm/min
 
-M558 K1 P8 C"!PB_11" H5 A5 S0.01 T1200 F600:300
+M558 K1 P8 C"!PB_11" H8 A5 S0.01 T1200 F600:300

--- a/milo-v1.5/ldo-kit-scylla-v1.0-24v/toolsetter.g
+++ b/milo-v1.5/ldo-kit-scylla-v1.0-24v/toolsetter.g
@@ -1,3 +1,3 @@
 ; toolsetter.g - Configures an optional toolsetter.
 ; NO Type
-M558 K1 P8 C"!PE_7" H2 A3 S0.01 T2500 F800:400
+M558 K1 P8 C"!PE_7" H8 A3 S0.01 T2500 F800:400

--- a/milo-v1.5/ldo-kit-scylla-v1.0-24v/touchprobe.g.example
+++ b/milo-v1.5/ldo-kit-scylla-v1.0-24v/touchprobe.g.example
@@ -1,3 +1,3 @@
 ; touchprobe.g - Configures an optional touch probe.
 ; NO Type
-M558 K0 P5 C"PE_15" H2 A3 S0.01 T2500 F600:150
+M558 K0 P5 C"PE_15" H5 A3 S0.01 T1200 F300:50


### PR DESCRIPTION
Safety net is a new system that allows for latching e-stop and power control confirmation when running MillenniumOS.

It configures an ATX Power Control pin using M81 at boot, and this can be detected by MillenniumOS, which prompts to enable machine power.